### PR TITLE
[LINUX BUILD] Mono port: support 64-bit builds, incl. non-apt distros

### DIFF
--- a/CLR_DEV9_LINUX_MONO/CMakeLists.txt
+++ b/CLR_DEV9_LINUX_MONO/CMakeLists.txt
@@ -10,9 +10,21 @@ add_library(${PROJECT_NAME} SHARED
 	PSE.cpp
 	)
 
-set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32 -Wl,-rpath,'$'ORIGIN/mono_i386/usr/lib")
-
-find_library(LIB_MONO NAMES monosgen-2.0 PATHS "${CMAKE_CURRENT_SOURCE_DIR}/mono_i386/usr/lib" NO_DEFAULT_PATH)
+execute_process(COMMAND ./build.sh get-arch RESULT_VARIABLE CMD_ARCH)
+if(CMD_ARCH MATCHES "x64")
+    find_library(LIB_MONO NAMES monosgen-2.0)
+else()
+    add_compile_options(-m32)
+    add_link_options(-m32)
+    execute_process(COMMAND ./build.sh get-apt RESULT_VARIABLE CMD_APT)
+    if(NOT CMD_APT MATCHES "")
+        add_link_options(-Wl,-rpath,'$'ORIGIN/mono_i386/usr/lib)
+        find_library(LIB_MONO NAMES monosgen-2.0 PATHS
+            "${CMAKE_CURRENT_SOURCE_DIR}/mono_i386/usr/lib" NO_DEFAULT_PATH)
+    else()
+        find_library(LIB_MONO NAMES monosgen-2.0)
+    endif()
+endif()
 
 target_link_libraries(${PROJECT_NAME}
 			${LIB_MONO}

--- a/CLR_DEV9_LINUX_MONO/build.sh
+++ b/CLR_DEV9_LINUX_MONO/build.sh
@@ -1,58 +1,72 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-./BundleMono.sh ./
-
-buildType=Debug
-if [ $# -gt 0 ] && [ $1 == "-release" ]; then
-    buildType=Release
-else
-    buildType=Debug
+# bundle mono for apt-based distros, use system Mono otherwise
+if command -v apt-get >/dev/null
+then
+    ./BundleMono.sh ./
 fi
-buildArch=x86
 
+buildType="Debug"
+if [[ "${1}" == "-release" ]]
+then
+    buildType="Release"
+fi
 
-if [ ! -f "../CLR_DEV9/bin/$buildType/CLR_DEV9.dll" ]; then
-    echo CLR_DEV9.dll Not Found
+# autodetect 32/64-bit based on PCSX2 binary
+# default to 32-bit if not in PATH
+buildArch="x86"
+if command -v PCSX2 >/dev/null && [[ "$(objdump -f $(command -v PCSX2) | grep "file format" | tr -s " " | cut -d " " -f 4)" == "elf64-x86-64" ]]
+then
+    buildArch="x64"
+fi
+
+if [[ "${1}" == "get-arch" ]] ; then echo "${buildArch}" ; exit 0 ; fi
+if [[ "${1}" == "get-apt" ]] ; then command -v apt-get ; exit 0 ; fi
+
+if [[ ! -f "../CLR_DEV9/bin/${buildType}/CLR_DEV9.dll" ]]; then
+    echo "CLR_DEV9.dll Not Found!  Place the Windows build of the appropriate architecture you want in $(realpath ../CLR_DEV9/bin/${buildType})"
     exit 1
 fi
 
-cp ../CLR_DEV9/bin/$buildType/CLR_DEV9.dll CLR_DEV9.dll
+cp -v ../CLR_DEV9/bin/$buildType/CLR_DEV9.dll CLR_DEV9.dll
 
-if [ ! -d "obj" ]; then
-    mkdir obj
+if [[ ! -d "obj" ]]; then
+    mkdir -vp obj
 fi
 
-objcopy --input binary --output elf32-i386 --binary-architecture i386 CLR_DEV9.dll obj/CLR_DEV9.o
+if [[ "${buildArch}" == "x64" ]]
+then
+    objcopy --input binary --output elf64-x86-64 --binary-architecture i386:x86-64 CLR_DEV9.dll obj/CLR_DEV9.o
+else
+    objcopy --input binary --output elf32-i386 --binary-architecture i386 CLR_DEV9.dll obj/CLR_DEV9.o
+fi
 
 cd obj
-
-if [ ! -d $buildArch ]; then
-    mkdir $buildArch
+if [[ ! -d "${buildArch}" ]]; then
+    mkdir -vp "${buildArch}"
 fi
-cd $buildArch
 
-if [ ! -d $buildType ]; then
-    mkdir $buildType
+cd "${buildArch}"
+if [[ ! -d "${buildType}" ]]; then
+    mkdir -vp "${buildType}"
 fi
-cd $buildType
 
-cmake -DCMAKE_BUILD_TYPE=$buildType ../../..
-make
+cd "${buildType}"
+cmake -DCMAKE_BUILD_TYPE="${buildType}" ../../..
+make VERBOSE=1
 
 cd ../../..
-
-if [ ! -d "bin" ]; then
-    mkdir bin
-fi
-if [ ! -d bin/$buildArch ]; then
-    mkdir bin/$buildArch
-fi
-if [ ! -d bin/$buildArch/$buildType ]; then
-    mkdir bin/$buildArch/$buildType
+if [ ! -d "bin/${buildArch}/${buildType}" ]; then
+    mkdir -vp "bin/${buildArch}/${buildType}"
 fi
 
-cp obj/$buildArch/$buildType/libclrdev9mono.so bin/$buildArch/$buildType/libclrdev9mono.so
+cp "obj/${buildArch}/${buildType}/libclrdev9mono.so" "bin/${buildArch}/${buildType}/libclrdev9mono.so"
 
-if [ -f bin/$buildArch/$buildType/libclrdev9mono.so ]; then
-    tar -zcvf bin/$buildArch/$buildType/libclrdev9mono.$buildType.tar.gz mono_i386 -C bin/$buildArch/$buildType/ libclrdev9mono.so
+if [[ -f "bin/${buildArch}/${buildType}/libclrdev9mono.so" ]]; then
+    if [[ -d "mono_i386" ]]
+    then
+        tar -zcvf "bin/${buildArch}/${buildType}/libclrdev9mono.${buildType}.tar.gz" "mono_i386" -C "bin/${buildArch}/${buildType}/" libclrdev9mono.so
+    else
+        tar -zcvf "bin/${buildArch}/${buildType}/libclrdev9mono.${buildType}.tar.gz" -C "bin/${buildArch}/${buildType}/" libclrdev9mono.so
+    fi
 fi


### PR DESCRIPTION
Surprisingly this worked without a hitch - the only problem is the configuration menu crashes (don't know if this is because of missing the bundled mono and using system instead?)  However the actual plugin functionality works with no config needed.  It detects architecture from the install PCSX2 binary.